### PR TITLE
Don't remove options from root tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,9 @@ const run = async ({ mode }: { mode: 'check' | 'write' }) => {
   const rootTSConfigString = await fs.readFile(rootTSConfigPath, {
     encoding: 'utf8',
   })
+  const rootTSConfig = JSON.parse(rootTSConfigString)
   const rootTSConfigTarget = {
+    ...rootTSConfig,
     files: [],
     references: idk
       .map((v) => v.tsConfigPath)


### PR DESCRIPTION
Right now, running this tool removes all existing keys from the root tsconfig.json.
This fix makes sure that if the root TSConfig has existing keys in it (other than files and references) they are not overwritten.